### PR TITLE
Fix w3c warnings/errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,11 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dotnet">
         <a class="navbar-brand" href="/">Sites of .NET</a>
         <ul class="navbar-nav mr-auto">
-            <a class="nav-link" href="https://github.com/terrajobst/sitesof.net">
-                <span class="oi oi-code pr-1"></span> Source
-            </a>
+            <li class="nav-item">
+                <a class="nav-link" href="https://github.com/terrajobst/sitesof.net">
+                    <span class="oi oi-code pr-1"></span> Source
+                </a>
+            </li>
         </ul>
     </nav>
     

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <div class="card-container">
 
             <div class="card site">
-                <img class="m-3" src="img/dotnet.png" class="card-img-top" alt=".NET Home">
+                <img class="m-3 card-img-top" src="img/dotnet.png" alt=".NET Home">
                 <div class="card-body">
                     <h5 class="card-title">dot.net</h5>
                     <p class="card-text">Primary landing page for getting started with .NET</p>
@@ -43,7 +43,7 @@
             </div>
 
             <div class="card site">
-                <img class="m-3" src="img/source.png" class="card-img-top" alt=".NET Source Browser">
+                <img class="m-3 card-img-top" src="img/source.png" alt=".NET Source Browser">
                 <div class="card-body">
                     <h5 class="card-title">source.dot.net</h5>
                     <p class="card-text">Indexed source code of the .NET platform</p>
@@ -52,7 +52,7 @@
             </div>
 
             <div class="card site">
-                <img class="m-3" src="https://issuesof.net/favicon.png" class="card-img-top" alt="Issues of .NET">
+                <img class="m-3 card-img-top" src="https://issuesof.net/favicon.png" alt="Issues of .NET">
                 <div class="card-body">
                     <h5 class="card-title">issuesof.net</h5>
                     <p class="card-text">Searching for bugs and feature requests for .NET</p>
@@ -61,7 +61,7 @@
             </div>
     
             <div class="card site">
-                <img class="m-3" src="https://themesof.net/favicon.png" class="card-img-top" alt="Themes of .NET">
+                <img class="m-3 card-img-top" src="https://themesof.net/favicon.png" alt="Themes of .NET">
                 <div class="card-body">
                     <h5 class="card-title">themesof.net</h5>
                     <p class="card-text">High-level planning of the next .NET version</p>
@@ -70,7 +70,7 @@
             </div>
 
             <div class="card site">
-                <img class="m-3" src="https://apisof.net/favicon.png" class="card-img-top" alt="APIs of .NET">
+                <img class="m-3 card-img-top" src="https://apisof.net/favicon.png" alt="APIs of .NET">
                 <div class="card-body">
                     <h5 class="card-title">apisof.net</h5>
                     <p class="card-text">List of .NET platform APIs and their availability</p>
@@ -79,7 +79,7 @@
             </div>
 
             <div class="card site">
-                <img class="m-3" src="https://designsof.net/favicon.png" class="card-img-top" alt="Designs of .NET">
+                <img class="m-3 card-img-top" src="https://designsof.net/favicon.png" alt="Designs of .NET">
                 <div class="card-body">
                     <h5 class="card-title">designsof.net</h5>
                     <p class="card-text">Design proposals for the .NET platform</p>
@@ -88,7 +88,7 @@
             </div>
 
             <div class="card site">
-                <img class="m-3" src="https://apireview.net/favicon.png" class="card-img-top" alt=".NET API Reviews">
+                <img class="m-3 card-img-top" src="https://apireview.net/favicon.png" alt=".NET API Reviews">
                 <div class="card-body">
                     <h5 class="card-title">apireview.net</h5>
                     <p class="card-text">List of API requests and upcoming reviews</p>


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/syntax.html#attributes-2:ascii-case-insensitive

> There must never be two or more attributes on the same start tag whose names are an ASCII case-insensitive match for each other.

No visual changes with this change. But it's the spec 😄 


https://validator.w3.org/ should be clean now ;)